### PR TITLE
Add "/api/errorlogs" endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The service will then store the following document in the database:
 
 ### Version info for installed extensions
 
-When your browser requests data from `update_url` endpoints directly, cookies with personal data might be transmitted along the way. For example, requests to `update_url`s of extensions obtained from Chrome Web Store usually include the following cookies with lots of personal and adtech-related data (even if you're not logged into your Google account!):
+When your browser requests data from `update_url` endpoints directly, cookies with personal data might be transmitted along the way. For example, requests to `update_url`s of extensions obtained from Chrome Web Store usually include the following cookies (with lots of personal and adtech-related data — even if you're not logged into your Google account!):
 
 * [1P_JAR](https://cookiepedia.co.uk/cookies/APISID/1P_JAR)
 * [APISID](https://cookiepedia.co.uk/cookies/APISID/APISID)
@@ -51,7 +51,7 @@ When your browser requests data from `update_url` endpoints directly, cookies wi
 
 (See also [https://policies.google.com/technologies/types](https://policies.google.com/technologies/types))
 
-If you don't like this, version info for installed extensions can be requested through this proxy which will strip all cookies:
+If you don't like this, all cookies can be stripped by using this proxy to request version info for installed extensions:
 
 Send a `POST` request to `/api` with the following JSON body:
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a service used by [Chromium Update Notifications](https://github.com/kkk
 ## Requirements
 
 - [Zeit's Now](https://zeit.co/)
-- A MongoDB database (for persistence)
+- A MongoDB database (for persistence and caching)
 - The environment variable `MONGODB_URI` provided via Now Secrets (prod) or a local `.env` file (dev)
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Chromium Extension Service
 
-This is a service used by [Chromium Update Notifications](https://github.com/kkkrist/chromium-notifier) primarily for error tracking. Legacy versions use it to fetch version info for installed extensions too.
+This is a service used by [Chromium Update Notifications](https://github.com/kkkrist/chromium-notifier) primarily for error tracking. Legacy versions use it to fetch version info for installed extensions.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Chromium Extension Service
 
-This is a service used by [Chromium Update Notifications](https://github.com/kkkrist/chromium-notifier) primarily for error tracking. Legacy versions use it to fetch version info for installed extensions.
+This is a service used by [Chromium Update Notifications](https://github.com/kkkrist/chromium-notifier) for error tracking and to increase privacy when fetching update info for installed extensions from the Chrome Web Store (strips cookies with personal data).
 
 ## Requirements
 
@@ -14,6 +14,8 @@ Note: The responses you see here is all that's ever saved anywhere, nothing else
 
 ### Error tracking
 
+Helps me to improve the extension.
+
 Send a `POST` request to `/api/errorlogs` with the following JSON body:
 
 ```json
@@ -22,7 +24,7 @@ Send a `POST` request to `/api/errorlogs` with the following JSON body:
 }
 ```
 
-The service will then store the following info in the database:
+The service will then store the following document in the database:
 
 ```json
 {
@@ -36,7 +38,20 @@ The service will then store the following info in the database:
 
 ### Version info for installed extensions
 
-Note: This is only used by Chromium Update Notifications prior to `v1.7.0`. Newer versions will hit `updateUrl` endpoints directly.
+When your browser requests data from `update_url` endpoints directly, cookies with personal data might be transmitted along the way. For example, requests to `update_url`s of extensions obtained from Chrome Web Store usually include the following cookies with lots of personal and adtech-related data (even if you're not logged into your Google account!):
+
+* [1P_JAR](https://cookiepedia.co.uk/cookies/APISID/1P_JAR)
+* [APISID](https://cookiepedia.co.uk/cookies/APISID/APISID)
+* [HSID](https://cookiepedia.co.uk/cookies/APISID/HSID)
+* [NID](https://cookiepedia.co.uk/cookies/APISID/NID)
+* [SAPISID](https://cookiepedia.co.uk/cookies/APISID/SAPISID)
+* [SID](https://cookiepedia.co.uk/cookies/APISID/SID)
+* [SIDCC](https://cookiepedia.co.uk/cookies/APISID/SIDCC)
+* [SSID](https://cookiepedia.co.uk/cookies/APISID/SSID)
+
+(See also [https://policies.google.com/technologies/types](https://policies.google.com/technologies/types))
+
+If you don't like this, version info for installed extensions can be requested through this proxy which will strip all cookies:
 
 Send a `POST` request to `/api` with the following JSON body:
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a service used by [Chromium Update Notifications](https://github.com/kkk
 
 ## Usage
 
-Note: The responses you see here is all that's ever saved anywhere, nothing else – particularly client (end user) data  – is collected.
+Note: The responses you see here is all that's ever saved anywhere, nothing else – particularly client (end user) data – is collected.
 
 ### Error tracking
 
@@ -18,21 +18,19 @@ Send a `POST` request to `/api/errorlogs` with the following JSON body:
 
 ```json
 {
-  "message": "<Error.prototype.message>",
-  "stack": "<Error.prototype.stack>"
+  "error": "JSON.stringify(<Error object>, Object.getOwnPropertyNames(<Error object>))"
 }
 ```
 
-The service will then store the following info in the database (the ip is hashed):
+The service will then store the following info in the database:
 
 ```json
 {
+  "_id": "5dc89e461f8c375aa22424cc",
   "createdAt": "2019-11-10T23:33:26.525Z",
-  "message": "<Error.prototype.message>",
-  "ip": "1a3a493b",
-  "stack": "<Error.prototype.stack>",
-  "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.390 4.97 Safari/537.36",
-  "_id": "5dc89e461f8c375aa22424cc"
+  "error": "<Error object>",
+  "hashedIp": "1a3a493b",
+  "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.390 4.97 Safari/537.36"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Chromium Extension Service
 
-This is a proxy service required by [Chromium Update Notifications](https://github.com/kkkrist/chromium-notifier) to fetch version info for installed extensions. It enables bypassing of [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) restrictions of the [Chrome Web Store](https://chrome.google.com/webstore/category/extensions) and tracking of GitHub-hosted extensions (see below).
+This is a service used by [Chromium Update Notifications](https://github.com/kkkrist/chromium-notifier) primarily for error tracking. Legacy versions use it to fetch version info for installed extensions too.
 
 ## Requirements
 
@@ -9,6 +9,36 @@ This is a proxy service required by [Chromium Update Notifications](https://gith
 - The environment variable `MONGODB_URI` provided via Now Secrets (prod) or a local `.env` file (dev)
 
 ## Usage
+
+Note: The responses you see here is all that's ever saved anywhere, nothing else – particularly client (end user) data  – is collected.
+
+### Error tracking
+
+Send a `POST` request to `/api/errorlogs` with the following JSON body:
+
+```json
+{
+  "message": "<Error.prototype.message>",
+  "stack": "<Error.prototype.stack>"
+}
+```
+
+The service will then store the following info in the database (the ip is hashed):
+
+```json
+{
+  "createdAt": "2019-11-10T23:33:26.525Z",
+  "message": "<Error.prototype.message>",
+  "ip": "1a3a493b",
+  "stack": "<Error.prototype.stack>",
+  "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.390 4.97 Safari/537.36",
+  "_id": "5dc89e461f8c375aa22424cc"
+}
+```
+
+### Version info for installed extensions
+
+Note: This is only used by Chromium Update Notifications prior to `v1.7.0`. Newer versions will hit `updateUrl` endpoints directly.
 
 Send a `POST` request to `/api` with the following JSON body:
 
@@ -46,5 +76,3 @@ The service will respond with an array consisting of version info and meta data 
   }
 ]
 ```
-
-Note: This is all that's ever saved anywhere, nothing else – particularly client (end user) data  – is collected.

--- a/api/errorlogs/index.js
+++ b/api/errorlogs/index.js
@@ -1,0 +1,48 @@
+const hashSum = require('hash-sum')
+const tokenthrottle = require('tokenthrottle')
+const getCollection = require('../../lib/get-collection')
+
+const throttle = tokenthrottle({
+  rate: 2,
+  window: 5 * 60 * 1000
+})
+
+module.exports = (req, res) =>
+  throttle.rateLimit(
+    req.headers['x-real-ip'] || req.connection.remoteAddress,
+    async (throttleError, limited) => {
+      try {
+        if (throttleError)
+          return res.status(500).json({ error: throttleError.message })
+
+        if (limited)
+          return res
+            .status(429)
+            .json({ error: 'Rate limit exceeded, please slow down.' })
+
+        if (req.method === 'OPTIONS') return res.end()
+
+        const { message, stack } = req.body || {}
+
+        if (!message || !stack)
+          return res.status(400).json({ error: 'Missing args!' })
+
+        const col = await getCollection(process.env.MONGODB_URI, 'errorlogs')
+
+        const report = {
+          createdAt: new Date(),
+          message,
+          ip: hashSum(req.headers['x-real-ip'] || req.connection.remoteAddress),
+          stack,
+          userAgent: req.headers['user-agent']
+        }
+
+        await col.insertOne(report)
+
+        return res.end()
+      } catch (error) {
+        console.error(error)
+        return res.status(500).json({ error: error.message })
+      }
+    }
+  )

--- a/api/errorlogs/index.js
+++ b/api/errorlogs/index.js
@@ -7,16 +7,6 @@ const throttle = tokenthrottle({
   window: 5 * 60 * 1000
 })
 
-/*
-fetch('http://localhost:3000/api/errorlogs', {
-  method: 'POST',
-  body: JSON.stringify({
-    error: JSON.stringify(error, Object.getOwnPropertyNames(error))
-  }),
-  headers: { 'Content-Type': 'application/json' }
-})
-*/
-
 module.exports = (req, res) => {
   try {
     if (req.method === 'OPTIONS') return res.end()

--- a/api/stats/index.js
+++ b/api/stats/index.js
@@ -11,7 +11,7 @@ const pipeline = [
         $max: '$timestamp'
       },
       updateUrl: {
-        $last: "$updateUrl"
+        $last: '$updateUrl'
       }
     }
   },

--- a/lib/get-collection.js
+++ b/lib/get-collection.js
@@ -1,10 +1,10 @@
 const MongoClient = require('mongodb').MongoClient
 const url = require('url')
 
-let _col = null
+const cache = []
 
-module.exports = async uri => {
-  if (_col) return _col
+module.exports = async (uri, collection = 'extensions') => {
+  if (cache[collection]) return cache[collection]
 
   const client = await MongoClient.connect(uri, {
     useNewUrlParser: true,
@@ -12,5 +12,5 @@ module.exports = async uri => {
   })
   const db = await client.db(url.parse(uri).pathname.substr(1))
 
-  return (_col = await db.collection('extensions'))
+  return (cache[collection] = await db.collection(collection))
 }

--- a/now.json
+++ b/now.json
@@ -4,9 +4,7 @@
   "env": {
     "MONGODB_URI": "@mongodb-uri"
   },
-  "regions": [
-    "bru1"
-  ],
+  "regions": ["bru1"],
   "routes": [
     {
       "src": "^/$",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
     "bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -22,6 +27,11 @@
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
+    "hash-sum": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
+      "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg=="
+    },
     "lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
@@ -31,6 +41,15 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lru-cache": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+      "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
+      "requires": {
+        "pseudomap": "^1.0.1",
+        "yallist": "^2.0.0"
+      }
     },
     "mongodb": {
       "version": "3.3.2",
@@ -61,6 +80,11 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
     "require_optional": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
@@ -85,6 +109,15 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
+    "tokenthrottle": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tokenthrottle/-/tokenthrottle-1.3.0.tgz",
+      "integrity": "sha1-UopZkpXiyCT7cv/stdTkgWOHWW0=",
+      "requires": {
+        "assert-plus": "~1.0.0",
+        "lru-cache": "~4.0.0"
+      }
+    },
     "xmltwojs": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xmltwojs/-/xmltwojs-4.0.0.tgz",
@@ -92,6 +125,11 @@
       "requires": {
         "node-expat": "^2.3.18"
       }
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
   },
   "homepage": "https://github.com/kkkrist/chromium-extension-service#readme",
   "dependencies": {
+    "hash-sum": "^2.0.0",
     "lodash.flatten": "^4.4.0",
     "lodash.get": "^4.4.2",
     "mongodb": "^3.3.2",
     "node-fetch": "^2.6.0",
+    "tokenthrottle": "^1.3.0",
     "xmltwojs": "^4.0.0"
   }
 }

--- a/stats/index.html
+++ b/stats/index.html
@@ -2,34 +2,38 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1" />
+    <meta
+      name="viewport"
+      content="width=device-width,minimum-scale=1,initial-scale=1"
+    />
     <title>Chromium Extension Service</title>
     <style>
-a {
-  color: inherit;
-}
-body {
-  color: #111;
-  font-family: monospace;
-}
-table {
-  text-align: left;
-}
-td, th {
-  border-bottom: 1px solid lightgrey;
-  padding: 0.75rem 1rem;
-  vertical-align: top;
-}
-th {
-  background-color: whitesmoke;
-  color: dimgrey;
-  text-transform: uppercase;
-}
-ul {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-}
+      a {
+        color: inherit;
+      }
+      body {
+        color: #111;
+        font-family: monospace;
+      }
+      table {
+        text-align: left;
+      }
+      td,
+      th {
+        border-bottom: 1px solid lightgrey;
+        padding: 0.75rem 1rem;
+        vertical-align: top;
+      }
+      th {
+        background-color: whitesmoke;
+        color: dimgrey;
+        text-transform: uppercase;
+      }
+      ul {
+        list-style-type: none;
+        margin: 0;
+        padding: 0;
+      }
     </style>
   </head>
 


### PR DESCRIPTION
Once the PR for [#16 in chromium-notifier](https://github.com/kkkrist/chromium-notifier/issues/16) lands, the base functionality of this service will be obsolete. As this will make debugging a lot harder, an endpoint to anonymously collect errors is needed. This PR provides said endpoint.